### PR TITLE
[1.x] Fix Uninitialized Property Error "$replaces"

### DIFF
--- a/src/LaravelStub.php
+++ b/src/LaravelStub.php
@@ -41,7 +41,7 @@ class LaravelStub
      *
      * @var array
      */
-    protected array $replaces;
+    protected array $replaces = [];
 
     /**
      * The stub file move or not.


### PR DESCRIPTION
This pull request addresses an issue in the Binafy\LaravelStub\LaravelStub class where the $replaces property could be accessed before it was initialized. This typically occurs when neither the replace() nor replaces() functions are used, leading to a PHP error:
`Typed property Binafy\LaravelStub\LaravelStub::$replaces must not be accessed before initialization`

These change ensure that the $replaces property is always properly initialized before use, preventing potential runtime errors and improving the stability of the package.