### PR TITLE
[1.x] Fix Facade's phpdoc return type

### DIFF
--- a/src/Facades/LaravelStub.php
+++ b/src/Facades/LaravelStub.php
@@ -5,14 +5,14 @@ namespace Binafy\LaravelStub\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static from(string $path): static
- * @method static to(string $to): static
- * @method static name(string $name): static
- * @method static ext(string $ext): static
- * @method static replace(string $key, mixed $value): static
- * @method static replaces(array $replaces): static
- * @method static download(): mixed
- * @method static generate(): bool
+ * @method static static from(string $path)
+ * @method static static to(string $to)
+ * @method static static name(string $name)
+ * @method static static ext(string $ext)
+ * @method static static replace(string $key, mixed $value)
+ * @method static static replaces(array $replaces)
+ * @method static mixed download()
+ * @method static bool generate()
  *
  * @see \Binafy\LaravelStub\LaravelStub
  */


### PR DESCRIPTION
The return type must be placed before the method name.
https://docs.phpdoc.org/2.9/references/phpdoc/tags/method.html:
`@method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]`

Before:
![image](https://github.com/binafy/laravel-stub/assets/26832856/6da476cd-c3c9-490d-a8f1-da7b7d02c244)

After:
![image](https://github.com/binafy/laravel-stub/assets/26832856/2d22b03a-fa2a-4b17-a2a5-7b2530477c40)
