### PR TITLE
[1.x] Refactor: Replace laravel/framework dependency with illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.0|^10.0|^11.0"
+        "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "pestphp/pest-plugin-laravel": "1.*|2.*",


### PR DESCRIPTION
This pull request updates the dependencies to use `illuminate/support` instead of the full `laravel/framework` package.

Why this change makes sense: Switching to `illuminate/support` instead of `laravel/framework` provides only the essential Laravel utilities and facades without the overhead of the entire framework, making the package lighter and more flexible. This change is especially beneficial for projects like Laravel Zero or other micro-frameworks that don’t require the full Laravel application stack, improving performance and reducing unnecessary dependencies.

Additional Context:

- I'm working on a Laravel Zero project and needed this package. Since Laravel Zero doesn’t include the whole Laravel framework, using `illuminate/support` makes it compatible with the setup.
- For a smaller package size and compatibility with the facades commonly used in Laravel, `illuminate/support` provides a more efficient solution, ensuring only the necessary components are included.

Thank you for considering this improvement!