### PR TITLE
[1.x] Add Conditional Code Block Handling in Stub Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ composer.lock
 .phpunit.result.cache
 .phpunit.xml
 coverage
-tests/App/new-test.php
+tests/App/*.php
 tests/Feature/test.stub

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [`replace`](#replace)
     - [`replaces`](#replaces)
     - [`moveStub`](#move-stub)
+    - [`conditions`](#conditions)
     - [`download`](#download)
     - [`generate`](#generate)
 - [Contributors](#contributors)
@@ -181,6 +182,49 @@ LaravelStub::from(__DIR__ . 'model.stub')
 ```
 
 After running this code, the `model.stub` didn't exist.
+
+<a name="conditions"></a>
+### `conditions`
+
+The `conditions` method allows you to define conditional blocks within your stub files.
+You can specify conditions that determine whether certain parts of the stub should be included or excluded based on provided values or closures.
+
+```php
+<?php
+LaravelStub::from(__DIR__ . 'model.stub')
+    ->to(__DIR__ . '/App')
+    ->name('new-model')
+    ->ext('php')
+    ->replaces([
+        'NAMESPACE' => 'App',
+        'CLASS' => 'Milwad'
+    ])
+    ->conditions([
+        'hasController' => true,
+        'hasController' => fn() => return false, // or with closure
+    ])
+    ->generate();
+```
+
+> NOTE: Ensure that your stub files contain the appropriate conditional placeholders (e.g., {{ if isEnabled }}) to utilize this method effectively.
+
+Your stub code should looks like this:
+
+```php
+<?php
+
+namespace {{ NAMESPACE }};
+
+class {{ CLASS }}
+{
+    {{ if hasController }}
+    public function controller()
+    {
+        // Controller logic here
+    }
+    {{ endif }}
+}
+```
 
 <a name="download"></a>
 ### `download`

--- a/src/Facades/LaravelStub.php
+++ b/src/Facades/LaravelStub.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static static replaces(array $replaces)
  * @method static mixed download()
  * @method static bool generate()
+ * @method static static conditions(array<string, bool|mixed|Closure> $conditions)
  *
  * @see \Binafy\LaravelStub\LaravelStub
  */

--- a/src/LaravelStub.php
+++ b/src/LaravelStub.php
@@ -2,6 +2,7 @@
 
 namespace Binafy\LaravelStub;
 
+use Closure;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Response;
 use RuntimeException;
@@ -49,6 +50,13 @@ class LaravelStub
      * @var bool
      */
     protected bool $moveStub = false;
+
+    /**
+     * The list of conditions.
+     *
+     * @var array
+     */
+    protected array $conditions = [];
 
     /**
      * Set stub path.
@@ -123,6 +131,19 @@ class LaravelStub
     }
 
     /**
+     * Set conditions.
+     *
+     * @param array<string, bool|mixed|Closure> $conditions
+     * @return static
+     */
+    public function conditions(array $conditions): static
+    {
+        $this->conditions = $conditions;
+
+        return $this;
+    }
+
+    /**
      * Download the stub file.
      */
     public function download()
@@ -139,7 +160,7 @@ class LaravelStub
     {
         // Check path is valid
         if (! File::exists($this->from)) {
-            throw new RuntimeException('The stub file does not exist, please enter a valid path.');
+            throw new RuntimeException("The {$this->from} stub file does not exist, please enter a valid path.");
         }
 
         // Check destination path is valid
@@ -154,6 +175,28 @@ class LaravelStub
         foreach ($this->replaces as $search => $value) {
             $content = str_replace("{{ $search }}", $value, $content);
         }
+
+        // Process conditions
+        foreach ($this->conditions as $condition => $value) {
+            if ($value instanceof Closure) {
+                $value = $value();
+            }
+
+            if ($value) {
+                // Remove condition placeholders along with any leading whitespace and newlines
+                $content = preg_replace("/^[ \t]*{{ if $condition }}\s*\n|^[ \t]*{{ endif }}\s*\n/m", '', $content);
+                continue;
+            }
+
+            // Remove the entire block including any leading whitespace and newlines
+            $content = preg_replace("/^[ \t]*{{ if $condition }}\s*\n.*?^[ \t]*{{ endif }}\s*\n/ms", '', $content);
+        }
+
+        // Remove any remaining conditional tags and their lines
+        $content = preg_replace("/^[ \t]*{{ if .*? }}\s*\n|^[ \t]*{{ endif .*? }}\s*\n/m", '', $content);
+
+        // Remove any remaining empty lines
+        $content = preg_replace("/^[ \t]*\n/m", '', $content);
 
         // Get correct path
         $path = $this->getPath();

--- a/tests/Feature/LaravelStubTest.php
+++ b/tests/Feature/LaravelStubTest.php
@@ -54,7 +54,7 @@ test('throw exception when stub path is invalid', function () {
 
     assertFileDoesNotExist(__DIR__ . '/../App/new-test.php');
     assertFileExists(__DIR__ . '/../App/test.stub');
-})->expectExceptionMessage('The stub file does not exist, please enter a valid path.');
+})->expectExceptionMessage('The test.stub stub file does not exist, please enter a valid path.');
 
 test('throw exception when destination path is invalid', function () {
     LaravelStub::from(__DIR__ . '/test.stub')

--- a/tests/Feature/LaravelStubTest.php
+++ b/tests/Feature/LaravelStubTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Binafy\LaravelStub\Facades\LaravelStub;
+use Illuminate\Support\Facades\File;
 
 use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertFileExists;
@@ -99,4 +100,54 @@ test('generate stub successfully with without any replaces', function () {
     assertTrue($generate);
     assertFileExists(__DIR__ . '/../App/new-test.php');
     assertFileDoesNotExist(__DIR__ . '/../App/test.stub');
+});
+
+test('generate stub successfully when all conditions are met', function () {
+    $stub = __DIR__ . '/test.stub';
+
+    $testCondition = true;
+
+    $generate = LaravelStub::from($stub)
+        ->to(__DIR__ . '/../App')
+        ->conditions([
+            'CONDITION_ONE' => true,
+            'CONDITION_TWO' => $testCondition,
+            'CONDITION_THREE' => fn() => true,
+        ])
+        ->name('conditional-test')
+        ->ext('php')
+        ->generate();
+
+    assertTrue($generate);
+    assertFileExists(__DIR__ . '/../App/conditional-test.php');
+
+    $content = File::get(__DIR__ . '/../App/conditional-test.php');
+    expect($content)->toContain('public function handle(): void');
+    expect($content)->toContain('public function users(): void');
+    expect($content)->toContain('public function roles(): void');
+});
+
+test('generate stub successfully when conditions are not met', function () {
+    $stub = __DIR__ . '/test.stub';
+
+    $testCondition = false;
+
+    $generate = LaravelStub::from($stub)
+        ->to(__DIR__ . '/../App')
+        ->conditions([
+            'CONDITION_ONE' => false,
+            'CONDITION_TWO' => $testCondition,
+            'CONDITION_THREE' => fn() => false,
+        ])
+        ->name('conditional-test-false')
+        ->ext('php')
+        ->generate();
+
+    assertTrue($generate);
+    assertFileExists(__DIR__ . '/../App/conditional-test-false.php');
+
+    $content = File::get(__DIR__ . '/../App/conditional-test-false.php');
+    expect($content)->not->toContain('public function handle(): void');
+    expect($content)->not->toContain('public function users(): void');
+    expect($content)->not->toContain('public function roles(): void');
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,9 +23,30 @@ namespace {{ NAMESPACE }};
 class {{ CLASS }}
 {
     use Illuminate\Database\Eloquent\Factories\{{ TRAIT }};
+
+    {{ if CONDITION_ONE }}
+        public function handle(): void
+        {
+            //
+        }
+    {{ endif }}
+
+    {{ if CONDITION_TWO }}
+        public function users(): void
+        {
+            //
+        }
+    {{ endif }}
+
+    {{ if CONDITION_THREE }}
+        public function roles(): void
+        {
+            //
+        }
+    {{ endif }}
 }
 EOL
-);
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request adds a feature to support conditional code blocks within stub files, allowing for the inclusion or exclusion of certain parts of the stubs based on custom conditions.

### Background
I’m working on a project where I need dependent stub files to be more dynamic for specific use cases.
Some code blocks within these stubs should only be included based on particular conditions.
Adding this feature would enable users to handle these scenarios without needing to manually edit generated files after publishing.

### Feature Details

- **Conditional Syntax:** This feature introduces `{{ if condition }} ... {{ endif }}` syntax within stub files to define conditional blocks.
- **Condition Evaluation:** When the stub is processed, the conditions are evaluated, and only code blocks that meet the conditions are included in the final output.
- **Backward Compatibility:** This feature is fully backward-compatible, so existing stubs without conditional blocks will continue to work as expected.

### Usage

```php
<?php

use Binafy\LaravelStub\Facades\LaravelStub;

LaravelStub::from(__DIR__ . 'model.stub')
    ->to(__DIR__ . '/App')
    ->name('new-model')
    ->ext('php')
    ->replaces([
        'NAMESPACE' => 'App',
        'CLASS' => 'Milwad'
    ])
    ->conditions([
        'hasController' => true,
        'hasController' => fn() => return false, // or with closure
    ])
    ->generate();
```

### Example Use Case

Suppose you’re generating model stubs that may or may not require specific Laravel features based on user preferences. For example, some models may need to support soft deletes or timestamps, while others do not. Instead of maintaining separate stubs for each combination, you can use conditional blocks to include these features only when they’re needed.

Here’s how it could look in the stub:


```php 
namespace App\Models;

use Illuminate\Database\Eloquent\Model;
@if($softDeletes)
use Illuminate\Database\Eloquent\SoftDeletes;
@endif

class {{ className }} extends Model
{
    {{ if softDeletes }}
    use SoftDeletes;

    protected $dates = ['deleted_at'];
    {{ endif }}

    {{ if timestamps }}
    public $timestamps = true;
    {{ endif }}

    protected $fillable = [
        // List of fillable attributes
    ];
}

```

In this example:

- Soft Deletes: If `softDeletes` is `true`, the generated model will include the `SoftDeletes` trait and set up the `deleted_at` column. If it’s `false`, these lines are excluded.
- Timestamps: If `timestamps` is `true`, the `timestamps` property is set to `true`

This approach saves time and reduces the need for duplicate stubs by allowing one stub file to handle multiple variations. It also keeps stubs easier to maintain, as updates only need to be applied to a single file instead of multiple, role-specific stubs.

### Testing
I've added unit tests to verify:

- Stub files with single and multiple conditional blocks.
- Nested conditions within stubs.
- Cases without conditions to confirm backward compatibility.

### Conclusion

This feature would be valuable for users who need more control over their stub files, allowing them to tailor generated files based on specific conditions. I’m open to any feedback and happy to make adjustments as needed. Thanks for considering this feature!