### PR TITLE
[1.x] Fix bug generate with conditions

### DIFF
--- a/src/LaravelStub.php
+++ b/src/LaravelStub.php
@@ -134,7 +134,6 @@ class LaravelStub
      * Set conditions.
      *
      * @param array<string, bool|mixed|Closure> $conditions
-     * @return static
      */
     public function conditions(array $conditions): static
     {
@@ -214,26 +213,33 @@ class LaravelStub
         }
 
         // Process conditions
-        foreach ($this->conditions as $condition => $value) {
-            if ($value instanceof Closure) {
-                $value = $value();
+        if (count($this->conditions) !== 0) {
+            foreach ($this->conditions as $condition => $value) {
+                if ($value instanceof Closure) {
+                    $value = $value();
+                }
+
+                if ($value) {
+                    // Replace placeholders for conditions that are true
+                    $content = preg_replace(
+                        "/^[ \t]*{{ if $condition }}\s*\n(.*?)(?=^[ \t]*{{ endif }}\s*\n)/ms",
+                        "$1",
+                        $content
+                    );
+                } else {
+                    // Remove the entire block for conditions that are false
+                    $content = preg_replace(
+                        "/^[ \t]*{{ if $condition }}\s*\n.*?^[ \t]*{{ endif }}\s*\n/ms",
+                        '',
+                        $content
+                    );
+                }
             }
 
-            if ($value) {
-                // Remove condition placeholders along with any leading whitespace and newlines
-                $content = preg_replace("/^[ \t]*{{ if $condition }}\s*\n|^[ \t]*{{ endif }}\s*\n/m", '', $content);
-                continue;
-            }
-
-            // Remove the entire block including any leading whitespace and newlines
-            $content = preg_replace("/^[ \t]*{{ if $condition }}\s*\n.*?^[ \t]*{{ endif }}\s*\n/ms", '', $content);
+            // Finally, clean up any remaining conditional tags and extra newlines
+            $content = preg_replace("/^[ \t]*{{ if .*? }}\s*\n|^[ \t]*{{ endif }}\s*\n/m", "\n", $content);
+            $content = preg_replace("/^[ \t]*\n/m", "\n", $content);
         }
-
-        // Remove any remaining conditional tags and their lines
-        $content = preg_replace("/^[ \t]*{{ if .*? }}\s*\n|^[ \t]*{{ endif .*? }}\s*\n/m", '', $content);
-
-        // Remove any remaining empty lines
-        $content = preg_replace("/^[ \t]*\n/m", '', $content);
 
         // Get correct path
         $path = $this->getPath();

--- a/tests/Feature/LaravelStubTest.php
+++ b/tests/Feature/LaravelStubTest.php
@@ -3,6 +3,7 @@
 use Binafy\LaravelStub\Facades\LaravelStub;
 use Illuminate\Support\Facades\File;
 
+use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertFileExists;
 use function PHPUnit\Framework\assertTrue;
@@ -105,14 +106,17 @@ test('generate stub successfully with without any replaces', function () {
 test('generate stub successfully when all conditions are met', function () {
     $stub = __DIR__ . '/test.stub';
 
-    $testCondition = true;
-
     $generate = LaravelStub::from($stub)
         ->to(__DIR__ . '/../App')
+        ->replaces([
+            'CLASS' => 'Milwad',
+            'NAMESPACE' => 'App\Models'
+        ])
+        ->replace('TRAIT', 'HasFactory')
         ->conditions([
             'CONDITION_ONE' => true,
-            'CONDITION_TWO' => $testCondition,
-            'CONDITION_THREE' => fn() => true,
+            'CONDITION_TWO' => true,
+            'CONDITION_THREE' => fn () => false,
         ])
         ->name('conditional-test')
         ->ext('php')
@@ -122,9 +126,13 @@ test('generate stub successfully when all conditions are met', function () {
     assertFileExists(__DIR__ . '/../App/conditional-test.php');
 
     $content = File::get(__DIR__ . '/../App/conditional-test.php');
-    expect($content)->toContain('public function handle(): void');
-    expect($content)->toContain('public function users(): void');
-    expect($content)->toContain('public function roles(): void');
+    expect($content)
+        ->toContain('public function handle(): void')
+        ->and($content)
+        ->toContain('public function users(): void')
+        ->and($content)
+        ->not
+        ->toContain('public function roles(): void');
 });
 
 test('generate stub successfully when conditions are not met', function () {
@@ -224,7 +232,7 @@ test('generate stub unsuccessfully with `generateIf` method', function () {
         ->ext('php')
         ->generateIf(false);
 
-    \PHPUnit\Framework\assertFalse($generate);
+    assertFalse($generate);
 });
 
 test('generate stub successfully with `generateUnless` method', function () {
@@ -259,5 +267,5 @@ test('generate stub unsuccessfully with `generateUnless` method', function () {
         ->ext('php')
         ->generateUnless(true);
 
-    \PHPUnit\Framework\assertFalse($generate);
+    assertFalse($generate);
 });


### PR DESCRIPTION
When you want to generate a stub with conditions, they will remove some spaces. In this PR, I've fixed it.

https://github.com/binafy/laravel-stub/pull/14